### PR TITLE
Resolves issue#1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,25 @@
 dist: trusty
 
 language: php
-php:
-  - '5.6'
-  - '7.0'
-  - '7.1'
-  - '7.2'
-  - '7.3'
+
+matrix:
+  include:
+  - php: '5.6'
+    env: COMPOSER_PREFER_LOWEST=true
+  - php: '5.6'
+    env: COMPOSER_PREFER_LOWEST=false
+  - php: '7.0'
+    env: COMPOSER_PREFER_LOWEST=true
+  - php: '7.0'
+    env: COMPOSER_PREFER_LOWEST=false
+  - php: '7.1'
+    env: COMPOSER_PREFER_LOWEST=true
+  - php: '7.1'
+    env: COMPOSER_PREFER_LOWEST=false
+  - php: '7.2'
+    env: COMPOSER_PREFER_LOWEST=false
+  - php: '7.3'
+    env: COMPOSER_PREFER_LOWEST=false
 
 branches:
   only: ['master']


### PR DESCRIPTION
# Changed log
- Resolves issue #1.
- The `php-7.2` and `php-7.3` will be failed when setting the `COMPOSER_PREFER_LOWEST` environment variable is `true`. The problem is about `PHPUnit` version, and the lower PHPUnit version cannot be worked well on `php-7.2` and `php-7.3` versions.